### PR TITLE
systemd: clear terminal after starting and before stopping

### DIFF
--- a/data/gdm.service.in
+++ b/data/gdm.service.in
@@ -5,6 +5,8 @@ After=systemd-user-sessions.service getty@tty@GDM_INITIAL_VT@.service plymouth-q
 
 [Service]
 ExecStart=@sbindir@/gdm
+ExecStartPost=-/bin/bash -c "TERM=linux /usr/bin/clear > /dev/tty1"
+ExecStop=-/bin/bash -c "TERM=linux /usr/bin/clear > /dev/tty1"
 Restart=always
 IgnoreSIGPIPE=no
 BusName=org.gnome.DisplayManager


### PR DESCRIPTION
This helps with flicker when the X server shuts down.

[endlessm/eos-shell#2227]