### PR TITLE
worker: setup password hint

### DIFF
--- a/daemon/gdm-session-worker.c
+++ b/daemon/gdm-session-worker.c
@@ -44,6 +44,8 @@
 #include <glib-object.h>
 #include <gio/gio.h>
 
+#include <act/act.h>
+
 #include <X11/Xauth.h>
 
 #ifdef WITH_SYSTEMD
@@ -1233,6 +1235,55 @@ gdm_session_worker_authenticate_user (GdmSessionWorker *worker,
         return TRUE;
 }
 
+static void
+user_loaded_cb (ActUser    *user,
+                GParamSpec *pspec,
+                gchar      *reminder)
+{
+        if (reminder != NULL) {
+                act_user_set_password_hint (user, reminder);
+                g_free (reminder);
+        } else {
+                act_user_set_password_mode (user, ACT_USER_PASSWORD_MODE_SET_AT_LOGIN);
+        }
+}
+
+static gboolean
+set_password_hint (GdmSessionWorker *worker)
+{
+        ActUser *user;
+        ActUserManager *manager;
+        char *password_reminder = NULL;
+        gboolean res;
+
+        g_debug ("GdmSessionWorker: authenticated user requires new password hint");
+        gdm_session_worker_report_problem (worker, _("Type a hint or question to help remember your password."));
+        res = gdm_session_worker_ask_question (worker, _("Password reminder:"), &password_reminder);
+        manager = act_user_manager_get_default ();
+        user = act_user_manager_get_user (manager, worker->priv->username);
+        password_reminder = g_strstrip (password_reminder);
+
+        if (password_reminder && password_reminder[0] == '\0') {
+                g_free (password_reminder);
+                password_reminder = NULL;
+        }
+
+        /* If operation was cancelled, or user doesn't set a reminder, we do nothing */
+        if (!res || password_reminder == NULL)
+                return res;
+
+        /* We use password_reminder variable in user_loaded_cb() to find out if
+           we must set the password hint (password_reminder != NULL) or we need
+           to reset the password mode because user cancelled the operation
+           (password_reminder == NULL) */
+        if (act_user_is_loaded (user))
+                user_loaded_cb (user, NULL, password_reminder);
+        else
+                g_signal_connect (user, "notify::is-loaded", G_CALLBACK (user_loaded_cb), password_reminder);
+
+        return res;
+}
+
 static gboolean
 gdm_session_worker_authorize_user (GdmSessionWorker *worker,
                                    gboolean          password_is_required,
@@ -1240,6 +1291,7 @@ gdm_session_worker_authorize_user (GdmSessionWorker *worker,
 {
         int error_code;
         int authentication_flags;
+        gboolean res;
 
         g_debug ("GdmSessionWorker: determining if authenticated user (password required:%d) is authorized to session",
                  password_is_required);
@@ -1267,6 +1319,9 @@ gdm_session_worker_authorize_user (GdmSessionWorker *worker,
                         gdm_session_auditor_report_password_change_failure (worker->priv->auditor);
                 } else {
                         gdm_session_auditor_report_password_changed (worker->priv->auditor);
+                        res = set_password_hint (worker);
+                        if (!res)
+                                error_code = PAM_ABORT;
                 }
         }
 


### PR DESCRIPTION
When asking for a new password in PAM<->Shell conversation, at the end
ask also for the password hint and save within user details.

[endlessm/eos-shell#1623]