### PR TITLE
Don't depend on gnome-icon-theme anymore

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -82,8 +82,7 @@ Recommends: zenity,
             x11-xkb-utils,
             xserver-xorg,
             at-spi2-core,
-            gnome-icon-theme,
-            gnome-icon-theme-symbolic,
+            adwaita-icon-theme,
             desktop-base (>= 6)
 Suggests: libpam-gnome-keyring,
           gnome-orca


### PR DESCRIPTION
It has been renamed to adwaita-icon-theme.

[endlessm/eos-shell#4538]