### PR TITLE
session-worker: set the display name as a TTY pam item on initialization

### DIFF
--- a/daemon/gdm-session-worker.c
+++ b/daemon/gdm-session-worker.c
@@ -1075,6 +1075,7 @@ gdm_session_worker_initialize_pam (GdmSessionWorker *worker,
 {
         struct pam_conv        pam_conversation;
         int                    error_code;
+        char                  *pam_tty;
 
         g_assert (worker->priv->pam_handle == NULL);
 
@@ -1134,6 +1135,25 @@ gdm_session_worker_initialize_pam (GdmSessionWorker *worker,
                         goto out;
                 }
         }
+
+        /* set TTY */
+        pam_tty = _get_tty_for_pam (x11_display_name, display_device);
+        if (pam_tty != NULL && pam_tty[0] != '\0') {
+                error_code = pam_set_item (worker->priv->pam_handle, PAM_TTY, pam_tty);
+
+                if (error_code != PAM_SUCCESS) {
+                        g_debug ("error informing authentication system of user's console %s: %s",
+                                 pam_tty,
+                                 pam_strerror (worker->priv->pam_handle, error_code));
+                        g_free (pam_tty);
+                        g_set_error (error,
+                                     GDM_SESSION_WORKER_ERROR,
+                                     GDM_SESSION_WORKER_ERROR_AUTHENTICATING,
+                                     "%s", "");
+                        goto out;
+                }
+        }
+        g_free (pam_tty);
 
 #ifdef WITH_SYSTEMD
         /* set seat ID */


### PR DESCRIPTION
For some reason this gets the right PAM modules (gkr-pam, pam_unix)
working for the use case of a passwordless user loging in for the 1st
time, so that the right auth error gets reported allowing to effectively
set the password for the 1st time from GDM.

This is probably not a real fix, but a workaround (and a partial revert
of 4cc94727) while we don't find the true reason why this is working
this way, so that users don't get a broken experience in the meanwhile.

[endlessm/eos-shell#5370]