### PR TITLE
Clear terminal after session has launched

### DIFF
--- a/daemon/gdm-simple-slave.c
+++ b/daemon/gdm-simple-slave.c
@@ -306,6 +306,7 @@ on_greeter_environment_session_started (GdmLaunchEnvironment *greeter_environmen
                                         GdmSimpleSlave       *slave)
 {
         g_debug ("GdmSimpleSlave: Greeter started");
+        g_spawn_command_line_async ("/bin/bash -c 'TERM=linux /usr/bin/clear > /dev/tty1'", NULL);
 }
 
 static void

--- a/data/gdm.service.in
+++ b/data/gdm.service.in
@@ -21,8 +21,6 @@ OnFailure=plymouth-quit.service
 
 [Service]
 ExecStart=@sbindir@/gdm
-ExecStartPost=-/bin/bash -c "TERM=linux /usr/bin/clear > /dev/tty1"
-ExecStopPost=-/bin/bash -c "TERM=linux /usr/bin/clear > /dev/tty1"
 KillMode=mixed
 Restart=always
 IgnoreSIGPIPE=no


### PR DESCRIPTION
We are seeing terminal messages on logout and shutdown. The first message
visible is: Started GNOME display manager

It is easy to see why this is happening - systemd prints this message
(and others) after gdm.service has fully started, which is even after
ExecStartPost.

On logout, there is no change to gdm.service state so nothing clears this.
On shutdown, it appears that ExecStopPost is too late to clear the
messages. For them to be truly hidden, the tty needs to be cleared before
the session is stopped.

I'm not exactly sure how this worked before, but this should be a more
reliable approach. We now clear the messages from inside the gdm process,
once a session has started successfully.

[endlessm/eos-shell#5458]