### PR TITLE
session-worker: Don't override PAM's password expired prompt

### DIFF
--- a/daemon/gdm-session-worker.c
+++ b/daemon/gdm-session-worker.c
@@ -1322,7 +1322,6 @@ gdm_session_worker_authorize_user (GdmSessionWorker *worker,
          */
         if (error_code == PAM_NEW_AUTHTOK_REQD && !worker->priv->is_program_session) {
                 g_debug ("GdmSessionWorker: authenticated user requires new auth token");
-                gdm_session_worker_report_problem (worker, _("Your password has expired, please change it now."));
                 error_code = pam_chauthtok (worker->priv->pam_handle, PAM_CHANGE_EXPIRED_AUTHTOK);
 
                 gdm_session_worker_get_username (worker, NULL);


### PR DESCRIPTION
gdm sends this message immediately after PAM sends an equivalent message,
resulting in the message being flashed too quickly for the user to read.

[endlessm/eos-shell#5894]