### PR TITLE
Attempt to avoid X session being terminated during gdm upgrades

### DIFF
--- a/data/gdm.service.in
+++ b/data/gdm.service.in
@@ -24,7 +24,8 @@ ExecStart=@sbindir@/gdm
 KillMode=mixed
 Restart=always
 IgnoreSIGPIPE=no
-BusName=org.gnome.DisplayManager
+# GDM is killed upon reload if BusName is set, let us forget it for now
+#BusName=org.gnome.DisplayManager
 StandardOutput=syslog
 StandardError=inherit
 EnvironmentFile=-@LANG_CONFIG_FILE@


### PR DESCRIPTION
Debian's gdm3 package removes the BusName entry in gdm's unit file,
which is evidently causing gdm to get killed during upgrades. This
changes the unit from type "dbus" to type "simple". The documented
effect of this change is that systemd will start services that
depend on gdm immediately, instead of waiting for gdm to take its
bus name. Frankly, the effects of this could be unpredictable, but
it is what Debian does, so it's probably fine....

[endlessm/eos-shell#5494]