### PR TITLE
Try harder to not die during upgrades

### DIFF
--- a/data/gdm.service.in
+++ b/data/gdm.service.in
@@ -21,8 +21,10 @@ OnFailure=plymouth-quit.service
 
 [Service]
 ExecStart=@sbindir@/gdm
+ExecReload=/bin/kill -HUP $MAINPID
 KillMode=mixed
 Restart=always
+RestartSec=1s
 IgnoreSIGPIPE=no
 # GDM is killed upon reload if BusName is set, let us forget it for now
 #BusName=org.gnome.DisplayManager


### PR DESCRIPTION
Handle restarts more like Debian, and less like gdm upstream. Might
work.

[endlessm/eos-shell#5494]