### PR TITLE
session-worker: Remove obsolete FIXME

### DIFF
--- a/daemon/gdm-session-worker.c
+++ b/daemon/gdm-session-worker.c
@@ -2907,9 +2907,7 @@ gdm_session_worker_handle_setup_for_user (GdmDBusWorker         *object,
                                   G_CALLBACK (on_saved_session_name_read),
                                   worker);
 
-        /* Load settings from accounts daemon before continuing
-         * FIXME: need to handle username not loading
-         */
+        /* Load settings from accounts daemon before continuing */
         worker->priv->pending_invocation = invocation;
         if (gdm_session_settings_load (worker->priv->user_settings, username)) {
                 queue_state_change (worker);


### PR DESCRIPTION
This comment led me on a bit of a wild goose chase, thinking that it is
possible for an ActUser to never load. Nowadays it will always load,
even if the username does not exist, and no further changes are required
in gdm. See fdo#66325.

https://bugzilla.gnome.org/show_bug.cgi?id=760401

[endlessm/eos-shell#5472]