### PR TITLE
Don't install anything from /usr/share/dconf

### DIFF
--- a/debian/gdm3.install
+++ b/debian/gdm3.install
@@ -9,7 +9,6 @@ usr/share/locale/
 usr/share/icons/
 usr/share/help/
 usr/share/gdm/
-usr/share/dconf/
 var/*
 
 debian/Xsession				etc/gdm3


### PR DESCRIPTION
There are no files installed in /usr/share/dconf at the moment due
to commit e1b4c1ec, so remove it not to fail building the package.

https://phabricator.endlessm.com/T16450