### PR TITLE
Don't ignore the default dconf settings set by upstream 

### DIFF
--- a/data/dconf/defaults/locks/00-upstream-settings-locks
+++ b/data/dconf/defaults/locks/00-upstream-settings-locks
@@ -10,7 +10,6 @@
 /org/gnome/desktop/lockdown/disable-print-setup
 /org/gnome/desktop/lockdown/disable-save-to-disk
 /org/gnome/desktop/lockdown/disable-user-switching
-/org/gnome/desktop/session/session-name
 /org/gnome/desktop/sound/event-sounds
 /org/gnome/settings-daemon/plugins/whitelisted-plugins
 /org/gnome/settings-daemon/plugins/media-keys/calculator

--- a/data/dconf/gdm.in
+++ b/data/dconf/gdm.in
@@ -1,2 +1,3 @@
 user-db:user
+system-db:gdm
 file-db:@DATADIR@/@PACKAGE@/greeter-dconf-defaults

--- a/data/dconf/gdm.in
+++ b/data/dconf/gdm.in
@@ -1,2 +1,2 @@
 user-db:user
-system-db:gdm
+file-db:@DATADIR@/@PACKAGE@/greeter-dconf-defaults


### PR DESCRIPTION
In the previous PR I overlooked the fact that now upstream defaults are no longer being used to update the binary database for the gdm profile as it used to, but instead a file-db is generated in-tree with dconf compile, which is supposed to be installed under /usr/share/gdm/greeter-dconf-defaults.

Thus, we can't simply replace the `file-db:@DATADIR@/@PACKAGE@/greeter-dconf-defaults` line with a `system-db:gdm` line and call it a day, since that means all the upstream defaults + locks will be ignored. Instead, what we have to do is to restore the `file-db` line and simply add the `system-db:gdm` line before it, so that the GDM db is considered first, then fall back to the upstream defaults.

Last, also backport a patch proposed upstream not to lock a setting that has not been previously set (`session-name`), which is wrong and causes GDM to fail to run on endless.

https://phabricator.endlessm.com/T16493