### PR TITLE
Properly install and handle upstream default dconf settings 

### DIFF
--- a/debian/gdm3.install
+++ b/debian/gdm3.install
@@ -18,4 +18,3 @@ var/*
 
 debian/Xsession				etc/gdm3
 debian/insserv.conf.d			etc
-data/dconf/defaults/*			usr/share/gdm/dconf

--- a/debian/gdm3.install
+++ b/debian/gdm3.install
@@ -13,6 +13,7 @@ usr/share/gdm/gdb-cmd
 usr/share/gdm/locale.alias
 usr/share/gdm/greeter
 usr/share/gdm/*.schemas
+usr/share/gdm/greeter-dconf-defaults
 usr/share/dconf/
 var/*
 

--- a/debian/gdm3.postinst
+++ b/debian/gdm3.postinst
@@ -64,6 +64,11 @@ if [ -L /etc/pam.d/gdm-welcome ]; then
     rm -f /etc/pam.d/gdm-welcome
 fi
 
+if [ "$1" = configure ]; then
+  # Create gdm system dconf db
+  dconf update
+fi
+
 #DEBHELPER#
 
 if [ -x /etc/init.d/gdm3 ]; then

--- a/debian/gdm3.postrm
+++ b/debian/gdm3.postrm
@@ -37,6 +37,9 @@ if [ "$1" = "purge" ] ; then
                         delgroup --system Debian-gdm || echo "Could not remove Debian-gdm group."
                 fi
         fi
+
+        # Remove gdm system dconf db
+        dconf update
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
Install the upstream default dconf settings, generated with `dconf compile`, in /usr/share/gdm/greeter-dconf-defaults, and include the result file in the gdm3 package, instead of the Debian-specific files that only the -now dropped- `generate-config` script would understand.

Also, in the previous PR I forgot to include the calls to `dconf update` that we need in Endless since we are not using the Debian-specific `generate-config` dynamic mechanism, so add that now too.

https://phabricator.endlessm.com/T16493