### PR TITLE
Remove plain text files with upstream's default settings on post inst

### DIFF
--- a/debian/gdm3.postinst
+++ b/debian/gdm3.postinst
@@ -64,6 +64,17 @@ if [ -L /etc/pam.d/gdm-welcome ]; then
     rm -f /etc/pam.d/gdm-welcome
 fi
 
+# Default upstream settings are no longer shipped as plain text files
+# that get compiled with dconf update, so we need to make sure we remove
+# them on dist-upgraded systems before running dconf update below, not
+# to get them added to the gdm profile's database again.
+if [ -f /etc/dconf/db/gdm.d/locks/00-upstream-settings-locks ]; then
+    rm -f /etc/dconf/db/gdm.d/locks/00-upstream-settings-locks
+fi
+if [ -f /etc/dconf/db/gdm.d/00-upstream-settings ]; then
+    rm -f /etc/dconf/db/gdm.d/00-upstream-settings
+fi
+
 if [ "$1" = configure ]; then
   # Create gdm system dconf db
   dconf update


### PR DESCRIPTION
Default upstream settings are no longer shipped as plain text files
that get compiled with dconf update. Instead, they used to compile
a dconf database at the time of building GDM, which will get installed
in /usr/share/gdm/greeter-dconf-defaults and referenced from the gdm
profile.

Thus, we need to make sure these files from previous versions of GDM get
removed on dist-upgraded systems before running dconf update below (which
we still want to allow extending the defaults with our own things), so that
old values and/or no longer used keys (e.g. session-name) don't get added
into the gdm profile's database.

This fixes an issue when dist-upgraded from eos-shell to gnome-shell 3.22,
as the old upstream-settings from GDM 3.14 file defined 'gdm-shell' as the
session name, making gnome-session fail as there's no gdm-shell.session
available in /usr/share/gnome-session/sessions, just the upstream one that
is now being used by debian: gnome.session.

This was not an issue with eos-shell because we installed our own overrides
in /etc/dconf/db/gdm.d that would override session-name with 'gdm-eos-shell',
which matches the gdm-eos-shell.session file installed by eos-shell, but
once eos-shell is uninstalled this override is gone, causing the problem
with upstream gnome-shell 3.22, as described above.

https://phabricator.endlessm.com/T2212