### PR TITLE
Don't fail installing/removing a package if dconf update fails

### DIFF
--- a/debian/gdm3.postinst
+++ b/debian/gdm3.postinst
@@ -76,8 +76,9 @@ if [ -f /etc/dconf/db/gdm.d/00-upstream-settings ]; then
 fi
 
 if [ "$1" = configure ]; then
-  # Create gdm system dconf db
-  dconf update
+  # Create gdm system dconf db, but don't make the package
+  # installation fail in case there's an error here, please.
+  dconf update || true
 fi
 
 #DEBHELPER#

--- a/debian/gdm3.postrm
+++ b/debian/gdm3.postrm
@@ -38,8 +38,9 @@ if [ "$1" = "purge" ] ; then
                 fi
         fi
 
-        # Remove gdm system dconf db
-        dconf update
+        # Remote gdm system dconf db, but don't make the package
+        # installation fail in case there's an error here, please.
+        dconf update || true
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
This call to dconf update is an Endless-specific thing, but we don't
want to have the package installation failing in case this call fails
for any reason (e.g. non-existent /etc/dconf/db directory), so make
it more robust against that.

https://phabricator.endlessm.com/T16823