### PR TITLE
T19191: create empty /etc/dconf/db/gdm.d

### DIFF
--- a/debian/gdm3.dirs
+++ b/debian/gdm3.dirs
@@ -3,6 +3,7 @@ etc/gdm3/Init
 etc/gdm3/PostLogin
 etc/gdm3/PreSession
 etc/gdm3/PostSession
+etc/dconf/db/gdm.d
 etc/dbus-1/system.d
 usr/share/gdm/BuiltInSessions
 var/lib/gdm3/.config/dconf


### PR DESCRIPTION
We previously shipped the gdm greeter session defaults in this folder, but it was later moved to a pre-compiled file in /usr. However, for backwards compatibility reasons in case the user/admin has customised their gdm.d folder with other settings, we still have system-db:gdm in the dconf profile for gdm. We call dconf update in the postinst script to create the /etc/dconf/db/gdm database but because gdm.d doesn't exist, the file is not created, causing a runtime error in dconf. The easiest fix that respects the possibility of user customisation is to create the dir (expecting it to be empty almost always) to create an empty GVariant db to keep dconf happy.

https://phabricator.endlessm.com/T19191