### PR TITLE
Revert "Clear terminal after session has launched"

### DIFF
--- a/daemon/gdm-display.c
+++ b/daemon/gdm-display.c
@@ -1399,7 +1399,6 @@ on_launch_environment_session_started (GdmLaunchEnvironment *launch_environment,
                                        GdmDisplay           *self)
 {
         g_debug ("GdmDisplay: Greeter started");
-        g_spawn_command_line_async ("/bin/bash -c 'TERM=linux /usr/bin/clear > /dev/tty1'", NULL);
 }
 
 static void


### PR DESCRIPTION
This reverts commit f0cf45d16fc5fcf3e17aec1e31d00c861b6e0a8f.

After upstream changes to the terminfo definitions on ncurses-base,
virtualbox VMs would boot to a black screen intead of the login manager.
Tracking down those changes, it boiled down to the definition of
capability E3 for linux3.0 terminals, which is now the default
definition for linux terminals. It seems the use of that capability on
framebuffer devices leads to clearing everything on the screen,
including the GDM user selector.

We'll revert manually clearing the terminal from GDM and work on a
better solution for the original problem (seeing terminal messages on
logout and shutdown, https://phabricator.endlessm.com/T5458).

https://phabricator.endlessm.com/T19555