### PR TITLE
daemon: clear the console's output when disconnecting from the display

### DIFF
--- a/daemon/gdm-display.c
+++ b/daemon/gdm-display.c
@@ -713,6 +713,10 @@ gdm_display_unmanage (GdmDisplay *self)
                 _gdm_display_set_status (self, GDM_DISPLAY_UNMANAGED);
         }
 
+        /* Make sure we clear the journal's text in the console if needed when
+         * disconnecting, not to bother the user with irrelevant messages. */
+        g_spawn_command_line_async ("/bin/bash -c '/usr/bin/tput -Tlinux reset > /dev/tty1'", NULL);
+
         return TRUE;
 }
 


### PR DESCRIPTION
Clear the screen here to prevent systemd messages from flashing when
logging out / restarting / shutting down, right before handing control
over to plymouth.

Note that we use `tput reset` instead of `clear` (or `tput clear`, which
woudl be equivalent) to make sure that we not only clear the text that
might be visible in the virtual terminal (tty1), but also any other
text that could be accessible by scrolling back. We could have used
`reset`, but that command is too heavy for what we want here (clearing
the console), which is something that `tput reset` does perfectly.

https://phabricator.endlessm.com/T18074