### PR TITLE
dconf: add image overrides location

### DIFF
--- a/data/dconf/gdm.in
+++ b/data/dconf/gdm.in
@@ -1,3 +1,4 @@
 user-db:user
 system-db:gdm
 file-db:@DATADIR@/@PACKAGE@/greeter-dconf-defaults
+file-db:/var/lib/eos-image-defaults/settings


### PR DESCRIPTION
Currently our image builder dconf overrides are not applied to the gdm
session. Make sure we include them there too, as some are required by
the initial-setup process too, which runs in the gdm session.

https://phabricator.endlessm.com/T24303