### PR TITLE
dconf: add image overrides location

### DIFF
--- a/data/dconf/gdm.in
+++ b/data/dconf/gdm.in
@@ -1,3 +1,4 @@
 user-db:user
 system-db:gdm
 file-db:@DATADIR@/@PACKAGE@/greeter-dconf-defaults
+file-db:/var/lib/eos-image-defaults/settings


### PR DESCRIPTION
Currently our image builder dconf overrides are not applied to the gdm
session. Make sure we include them there too, so any image-specific
wallpaper is used when the greeter session becomes idle.

This is the same change 2b57d58bc521d7ddbacdd338aa2ea9fe47e038a2 (#48), which
was reverted in f56e0a4a12212325ffd63aac9182c5013165811c because it did
not fix the original issue of the custom wallpaper not being used during
the FBE. However, this change does fix the issue of the wrong wallpaper
being used when the login screen becomes idle.

https://phabricator.endlessm.com/T24907