### PR TITLE
Revert "daemon: clear the console's output when disconnecting from the display"

### DIFF
--- a/daemon/gdm-display.c
+++ b/daemon/gdm-display.c
@@ -713,10 +713,6 @@ gdm_display_unmanage (GdmDisplay *self)
                 _gdm_display_set_status (self, GDM_DISPLAY_UNMANAGED);
         }
 
-        /* Make sure we clear the journal's text in the console if needed when
-         * disconnecting, not to bother the user with irrelevant messages. */
-        g_spawn_command_line_async ("/bin/bash -c '/usr/bin/tput -Tlinux reset > /dev/tty1'", NULL);
-
         return TRUE;
 }
 


### PR DESCRIPTION
This reverts commit 20c4d5261618cd2d00c5217ed656e12714ecfbde.

Now that the systemd-plymouth integration is fixed systemd does not
print to the console except when plymouth is running, in which case
console redirection is also enabled so all of systemd's output is
printed to a file insted of the actual console.

The only other thing that could print to the console is the kernel,
however, after the work on T24262 it should not print anything to the
console unless the previous boot failed, in which case we don't care
about having a clean shutdown since the boot was already full of
messages.

https://phabricator.endlessm.com/T25396