### PR TITLE
Full disable user display server again

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,11 +8,6 @@ include /usr/share/gnome-pkg-tools/1/rules/gnome-version.mk
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,-z,defs -Wl,--as-needed
 
-ifeq (,$(filter i386 amd64,$(DEB_HOST_ARCH_CPU)))
-CONFFLAGS += \
-	--disable-user-display-server
-endif
-
 ifeq (linux,$(DEB_HOST_ARCH_OS))
 CONFFLAGS += \
 	--enable-wayland-support \
@@ -62,6 +57,7 @@ override_dh_auto_configure:
 		--libexecdir=\$${prefix}/lib/gdm3 \
 		--disable-static \
 		--enable-ipv6=yes \
+		--disable-user-display-server \
 		--with-at-spi-registryd-directory=/usr/lib/at-spi \
 		--with-default-path=/usr/local/bin:/usr/bin:/bin:/usr/games \
 		--with-custom-conf=/etc/gdm3/daemon.conf \


### PR DESCRIPTION
With the update to gdm-3.32, we turned on user display server
functionality.

However, this breaks nvidia device support. Reproduced on Asus P4540UQ:

(EE) NVIDIA: Failed to initialize the NVIDIA kernel module. Please see the
(EE) NVIDIA:     system's kernel log for additional error messages and
(EE) NVIDIA:     consult the NVIDIA README for details.
(EE) NVIDIA: Failed to initialize the NVIDIA kernel module. Please see the
(EE) NVIDIA:     system's kernel log for additional error messages and
(EE) NVIDIA:     consult the NVIDIA README for details.
(EE) [drm] Failed to open DRM device for (null): -22
(EE) [drm] Failed to open DRM device for pci:0000:01:00.0: -19
(EE) open /dev/dri/card1: Permission denied
(WW) Falling back to old probe method for modesetting
(II) modeset(1): using default device
(WW) Falling back to old probe method for fbdev
(II) Loading sub module "fbdevhw"
(II) LoadModule: "fbdevhw"
(II) Loading /usr/lib/xorg/modules/libfbdevhw.so
(II) Module fbdevhw: vendor="X.Org Foundation"
        compiled for 1.20.3, module version = 0.0.2
        ABI class: X.Org Video Driver, version 24.0
(EE) open /dev/fb0: Permission denied
(EE) [drm] Failed to open DRM device for (null): -22
(II) modeset(G0): using drv /dev/dri/card0
(EE) open /dev/dri/card1: Permission denied
(WW) VGA arbiter: cannot open kernel arbiter, no multi-card support
(EE) Screen 0 deleted because of no matching config section.
(II) UnloadModule: "modesetting"
Fatal server error:
(EE) Cannot run in framebuffer mode. Please specify busIDs        for all framebuffer devices

In addition to the nvidia DRM device not having appropriate permissions
applied, the "Failed to initialize the NVIDIA kernel module" error
refers to something else that is not accessible as a user, but after a
few mins of poking I couldn't figure out that is trying to access.

Restore the eos3.5 behaviour of disabling the user display server
to make nvidia work again.

https://phabricator.endlessm.com/T25368