### PR TITLE
Kill Xorg

### DIFF
--- a/common/gdm-common.c
+++ b/common/gdm-common.c
@@ -847,12 +847,14 @@ gdm_shell_expand (const char *str,
 static void
 load_env_file (GFile *file,
                GdmLoadEnvVarFunc load_env_func,
+               GdmExpandVarFunc  expand_func,
                gpointer user_data)
 {
         gchar *contents;
         gchar **lines;
         gchar *line, *p;
         gchar *var, *var_end;
+        gchar *expanded;
         char *filename;
         int i;
 
@@ -885,7 +887,10 @@ load_env_file (GFile *file,
                         while (g_ascii_isspace (*p))
                                 p++;
 
-                        load_env_func (var, p, user_data);
+                        expanded = gdm_shell_expand (p, expand_func, user_data);
+                        expanded = g_strchomp (expanded);
+                        load_env_func (var, expanded, user_data);
+                        g_free (expanded);
                 }
                 g_strfreev (lines);
         }
@@ -901,6 +906,7 @@ compare_str (gconstpointer  a,
 static void
 gdm_load_env_dir (GFile *dir,
                   GdmLoadEnvVarFunc load_env_func,
+                  GdmExpandVarFunc  expand_func,
                   gpointer user_data)
 {
         GFileInfo *info = NULL;
@@ -936,7 +942,7 @@ gdm_load_env_dir (GFile *dir,
         for (i = 0; i < names->len; i++) {
                 name = g_ptr_array_index (names, i);
                 file = g_file_get_child (dir, name);
-                load_env_file (file, load_env_func, user_data);
+                load_env_file (file, load_env_func, expand_func, user_data);
                 g_object_unref (file);
         }
 
@@ -947,15 +953,16 @@ gdm_load_env_dir (GFile *dir,
 
 void
 gdm_load_env_d (GdmLoadEnvVarFunc load_env_func,
+                GdmExpandVarFunc  expand_func,
                 gpointer user_data)
 {
         GFile *dir;
 
         dir = g_file_new_for_path (DATADIR "/gdm/env.d");
-        gdm_load_env_dir (dir, load_env_func, user_data);
+        gdm_load_env_dir (dir, load_env_func, expand_func, user_data);
         g_object_unref (dir);
 
         dir = g_file_new_for_path (GDMCONFDIR "/env.d");
-        gdm_load_env_dir (dir, load_env_func, user_data);
+        gdm_load_env_dir (dir, load_env_func, expand_func, user_data);
         g_object_unref (dir);
 }

--- a/common/gdm-common.c
+++ b/common/gdm-common.c
@@ -843,3 +843,119 @@ gdm_shell_expand (const char *str,
         }
         return g_string_free (s, FALSE);
 }
+
+static void
+load_env_file (GFile *file,
+               GdmLoadEnvVarFunc load_env_func,
+               gpointer user_data)
+{
+        gchar *contents;
+        gchar **lines;
+        gchar *line, *p;
+        gchar *var, *var_end;
+        char *filename;
+        int i;
+
+        filename = g_file_get_path (file);
+        g_debug ("Loading env vars from %s\n", filename);
+        g_free (filename);
+
+        if (g_file_load_contents (file, NULL, &contents, NULL, NULL, NULL)) {
+                lines = g_strsplit (contents, "\n", -1);
+                g_free (contents);
+                for (i = 0; lines[i] != NULL; i++) {
+                        line = lines[i];
+                        p = line;
+                        while (g_ascii_isspace (*p))
+                                p++;
+                        if (*p == '#' || *p == '\0')
+                                continue;
+                        var = p;
+                        while (gdm_shell_var_is_valid_char (*p, p == var))
+                                p++;
+                        var_end = p;
+                        while (g_ascii_isspace (*p))
+                                p++;
+                        if (var == var_end || *p != '=') {
+                                g_warning ("Invalid env.d line '%s'\n", line);
+                                continue;
+                        }
+                        *var_end = 0;
+                        p++; /* Skip = */
+                        while (g_ascii_isspace (*p))
+                                p++;
+
+                        load_env_func (var, p, user_data);
+                }
+                g_strfreev (lines);
+        }
+}
+
+static gint
+compare_str (gconstpointer  a,
+             gconstpointer  b)
+{
+  return strcmp (*(const char **)a, *(const char **)b);
+}
+
+static void
+gdm_load_env_dir (GFile *dir,
+                  GdmLoadEnvVarFunc load_env_func,
+                  gpointer user_data)
+{
+        GFileInfo *info = NULL;
+        GFileEnumerator *enumerator = NULL;
+        GPtrArray *names = NULL;
+        GFile *file;
+        const gchar *name;
+        int i;
+
+        enumerator = g_file_enumerate_children (dir,
+                                                G_FILE_ATTRIBUTE_STANDARD_TYPE","
+                                                G_FILE_ATTRIBUTE_STANDARD_NAME","
+                                                G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN","
+                                                G_FILE_ATTRIBUTE_STANDARD_IS_BACKUP,
+                                                G_FILE_QUERY_INFO_NONE,
+                                                NULL, NULL);
+        if (!enumerator) {
+                goto out;
+        }
+
+        names = g_ptr_array_new_with_free_func (g_free);
+        while ((info = g_file_enumerator_next_file (enumerator, NULL, NULL)) != NULL) {
+                if (g_file_info_get_file_type (info) == G_FILE_TYPE_REGULAR &&
+                    !g_file_info_get_is_hidden (info) &&
+                    g_str_has_suffix (g_file_info_get_name (info), ".env"))
+                  g_ptr_array_add (names, g_strdup (g_file_info_get_name (info)));
+
+                g_clear_object (&info);
+        }
+
+        g_ptr_array_sort (names, compare_str);
+
+        for (i = 0; i < names->len; i++) {
+                name = g_ptr_array_index (names, i);
+                file = g_file_get_child (dir, name);
+                load_env_file (file, load_env_func, user_data);
+                g_object_unref (file);
+        }
+
+ out:
+        g_clear_pointer (&names, g_ptr_array_unref);
+        g_clear_object (&enumerator);
+}
+
+void
+gdm_load_env_d (GdmLoadEnvVarFunc load_env_func,
+                gpointer user_data)
+{
+        GFile *dir;
+
+        dir = g_file_new_for_path (DATADIR "/gdm/env.d");
+        gdm_load_env_dir (dir, load_env_func, user_data);
+        g_object_unref (dir);
+
+        dir = g_file_new_for_path (GDMCONFDIR "/env.d");
+        gdm_load_env_dir (dir, load_env_func, user_data);
+        g_object_unref (dir);
+}

--- a/common/gdm-common.h
+++ b/common/gdm-common.h
@@ -39,6 +39,10 @@ GQuark gdm_common_error_quark (void);
 typedef char * (*GdmExpandVarFunc) (const char *var,
                                     gpointer user_data);
 
+typedef void   (*GdmLoadEnvVarFunc) (const char *var,
+                                     const char *value,
+                                     gpointer user_data);
+
 G_BEGIN_DECLS
 
 int            gdm_wait_on_pid           (int pid);
@@ -76,6 +80,9 @@ char *        gdm_shell_expand            (const char *str,
 gboolean      gdm_activate_session_by_id (GDBusConnection *connection,
                                           const char      *seat_id,
                                           const char      *session_id);
+
+void          gdm_load_env_d              (GdmLoadEnvVarFunc load_env_func,
+                                           gpointer          user_data);
 
 G_END_DECLS
 

--- a/common/gdm-common.h
+++ b/common/gdm-common.h
@@ -82,6 +82,7 @@ gboolean      gdm_activate_session_by_id (GDBusConnection *connection,
                                           const char      *session_id);
 
 void          gdm_load_env_d              (GdmLoadEnvVarFunc load_env_func,
+                                           GdmExpandVarFunc  expand_func,
                                            gpointer          user_data);
 
 G_END_DECLS

--- a/common/gdm-settings-keys.h
+++ b/common/gdm-settings-keys.h
@@ -29,6 +29,7 @@ G_BEGIN_DECLS
 #define GDM_KEY_GROUP "daemon/Group"
 #define GDM_KEY_AUTO_LOGIN_ENABLE "daemon/AutomaticLoginEnable"
 #define GDM_KEY_AUTO_LOGIN_USER "daemon/AutomaticLogin"
+#define GDM_KEY_FORCE_AUTO_LOGIN "daemon/ForceAutomaticLogin"
 #define GDM_KEY_TIMED_LOGIN_ENABLE "daemon/TimedLoginEnable"
 #define GDM_KEY_TIMED_LOGIN_USER "daemon/TimedLogin"
 #define GDM_KEY_TIMED_LOGIN_DELAY "daemon/TimedLoginDelay"

--- a/configure.ac
+++ b/configure.ac
@@ -1135,7 +1135,10 @@ dnl ---------------------------------------------------------------------------
 # and /usr/X11 since they often symlink to each other, and configure
 # should use the more stable location (the real directory) if possible.
 #
-if test -x /usr/bin/X; then
+if test -n "$X_PATH"; then
+   # assume the user set these variables and don't second-guess them.
+   true
+elif test -x /usr/bin/X; then
    X_PATH="/usr/bin"
    X_SERVER_PATH="/usr/bin"
    X_SERVER="/usr/bin/X"

--- a/configure.ac
+++ b/configure.ac
@@ -148,6 +148,7 @@ PKG_CHECK_MODULES(CHECK,
                   have_check=yes,
                   have_check=no)
 AM_CONDITIONAL([HAVE_CHECK],[test "x$CHECK_CFLAGS" != "x"])
+CHECK_LIBS="$CHECK_LIBS -lrt -lm"
 
 PKG_CHECK_MODULES(LIBGDM, glib-2.0 gio-2.0 gio-unix-2.0);
 GOBJECT_INTROSPECTION_CHECK([0.9.12])

--- a/daemon/gdm-launch-environment.c
+++ b/daemon/gdm-launch-environment.c
@@ -115,6 +115,23 @@ static void     gdm_launch_environment_finalize      (GObject                   
 
 G_DEFINE_TYPE (GdmLaunchEnvironment, gdm_launch_environment, G_TYPE_OBJECT)
 
+static char *
+get_var_cb (const char *var,
+            gpointer user_data)
+{
+        const char *value = g_hash_table_lookup (user_data, var);
+        return g_strdup (value);
+}
+
+static void
+load_env_func (const char *var,
+               const char *value,
+               gpointer user_data)
+{
+        GHashTable *environment = user_data;
+        g_hash_table_replace (environment, g_strdup (var), g_strdup (value));
+}
+
 static GHashTable *
 build_launch_environment (GdmLaunchEnvironment *launch_environment,
                           gboolean              start_session)
@@ -160,15 +177,6 @@ build_launch_environment (GdmLaunchEnvironment *launch_environment,
                                      g_strdup (optional_environment[i]),
                                      g_strdup (g_getenv (optional_environment[i])));
         }
-
-        system_data_dirs = g_strjoinv (":", (char **) g_get_system_data_dirs ());
-
-        g_hash_table_insert (hash,
-                             g_strdup ("XDG_DATA_DIRS"),
-                             g_strdup_printf ("%s:%s",
-                                              DATADIR "/gdm/greeter",
-                                              system_data_dirs));
-        g_free (system_data_dirs);
 
         if (launch_environment->priv->x11_authority_file != NULL)
                 g_hash_table_insert (hash, g_strdup ("XAUTHORITY"), g_strdup (launch_environment->priv->x11_authority_file));
@@ -219,6 +227,24 @@ build_launch_environment (GdmLaunchEnvironment *launch_environment,
         }
 
         g_hash_table_insert (hash, g_strdup ("RUNNING_UNDER_GDM"), g_strdup ("true"));
+
+        /* Now populate XDG_DATA_DIRS from env.d if we're running initial setup; this allows
+         * e.g. Flatpak apps to be recognized by gnome-shell.
+         */
+        if (g_strcmp0 (launch_environment->priv->session_mode, INITIAL_SETUP_SESSION_MODE) == 0)
+                gdm_load_env_d (load_env_func, get_var_cb, hash);
+
+        /* Prepend our own XDG_DATA_DIRS value */
+        system_data_dirs = g_strdup (g_hash_table_lookup (hash, "XDG_DATA_DIRS"));
+        if (!system_data_dirs)
+                system_data_dirs = g_strjoinv (":", (char **) g_get_system_data_dirs ());
+
+        g_hash_table_insert (hash,
+                             g_strdup ("XDG_DATA_DIRS"),
+                             g_strdup_printf ("%s:%s",
+                                              DATADIR "/gdm/greeter",
+                                              system_data_dirs));
+        g_free (system_data_dirs);
 
         return hash;
 }

--- a/daemon/gdm-local-display-factory.c
+++ b/daemon/gdm-local-display-factory.c
@@ -616,7 +616,6 @@ static void
 maybe_stop_greeter_in_background (GdmLocalDisplayFactory *factory,
                                   GdmDisplay             *display)
 {
-        g_autofree char *display_session_type = NULL;
         gboolean doing_initial_setup = FALSE;
 
         if (gdm_display_get_status (display) != GDM_DISPLAY_MANAGED) {
@@ -625,20 +624,12 @@ maybe_stop_greeter_in_background (GdmLocalDisplayFactory *factory,
         }
 
         g_object_get (G_OBJECT (display),
-                      "session-type", &display_session_type,
                       "doing-initial-setup", &doing_initial_setup,
                       NULL);
 
         /* we don't ever stop initial-setup implicitly */
         if (doing_initial_setup) {
                 g_debug ("GdmLocalDisplayFactory: login window is performing initial-setup, so ignoring");
-                return;
-        }
-
-        /* we can only stop greeter for wayland sessions, since
-         * X server would jump back on exit */
-        if (g_strcmp0 (display_session_type, "wayland") != 0) {
-                g_debug ("GdmLocalDisplayFactory: login window is running on Xorg, so ignoring");
                 return;
         }
 

--- a/daemon/gdm-manager.c
+++ b/daemon/gdm-manager.c
@@ -1409,6 +1409,7 @@ set_up_session (GdmManager *manager,
         gboolean loaded;
         gboolean seat_can_autologin = FALSE, seat_did_autologin = FALSE;
         gboolean autologin_enabled = FALSE;
+        gboolean forced_autologin = FALSE;
         g_autofree char *seat_id = NULL;
         char *username = NULL;
 
@@ -1420,7 +1421,9 @@ set_up_session (GdmManager *manager,
         if (manager->priv->did_automatic_login || manager->priv->automatic_login_display != NULL)
                 seat_did_autologin = TRUE;
 
-        if (seat_can_autologin && !seat_did_autologin)
+        gdm_settings_direct_get_boolean (GDM_KEY_FORCE_AUTO_LOGIN, &forced_autologin);
+
+        if (seat_can_autologin && (!seat_did_autologin || forced_autologin))
                 autologin_enabled = get_automatic_login_details (manager, &username);
 
         if (!autologin_enabled) {

--- a/daemon/gdm-session-worker.c
+++ b/daemon/gdm-session-worker.c
@@ -1621,12 +1621,7 @@ load_env_func (const char *var,
                gpointer user_data)
 {
         GdmSessionWorker *worker = user_data;
-        char *expanded;
-
-        expanded = gdm_shell_expand (value, get_var_cb, worker);
-        expanded = g_strchomp (expanded);
-        gdm_session_worker_set_environment_variable (worker, var, expanded);
-        g_free (expanded);
+        gdm_session_worker_set_environment_variable (worker, var, value);
 }
 
 static gboolean
@@ -2057,7 +2052,7 @@ gdm_session_worker_start_session (GdmSessionWorker  *worker,
 #endif
 
                 if (!worker->priv->is_program_session) {
-                        gdm_load_env_d (load_env_func, worker);
+                        gdm_load_env_d (load_env_func, get_var_cb, worker);
                 }
 
                 environment = gdm_session_worker_get_environment (worker);

--- a/daemon/gdm-session-worker.c
+++ b/daemon/gdm-session-worker.c
@@ -47,6 +47,8 @@
 #include <glib-object.h>
 #include <gio/gio.h>
 
+#include <act/act.h>
+
 #include <X11/Xauth.h>
 
 #include <systemd/sd-daemon.h>
@@ -1300,6 +1302,67 @@ gdm_session_worker_authenticate_user (GdmSessionWorker *worker,
         return TRUE;
 }
 
+static void
+user_loaded_cb (ActUser    *user,
+                GParamSpec *pspec,
+                gchar      *reminder)
+{
+        if (reminder != NULL) {
+                act_user_set_password_hint (user, reminder);
+                g_free (reminder);
+        } else {
+                act_user_set_password_mode (user, ACT_USER_PASSWORD_MODE_SET_AT_LOGIN);
+        }
+}
+
+static gboolean
+set_password_hint (GdmSessionWorker *worker)
+{
+        ActUser *user = NULL;
+        ActUserManager *manager = NULL;
+
+        char *password_reminder = NULL;
+
+        gboolean res = TRUE;
+
+        g_debug ("GdmSessionWorker: authenticated user requires new password hint");
+
+        while (res && password_reminder == NULL) {
+                gdm_session_worker_report_problem (worker, _("Type a hint or question to help remember your password."));
+                res = gdm_session_worker_ask_question (worker, _("Password reminder:"), &password_reminder);
+
+                if (password_reminder && password_reminder[0] == '\0') {
+                        g_free (password_reminder);
+                        password_reminder = NULL;
+                }
+        }
+
+        /* If they got past the hint screen with a whitespace, ignore setting the hint */
+        password_reminder = g_strstrip (password_reminder);
+        if (password_reminder[0] == '\0') {
+            g_free (password_reminder);
+            password_reminder = NULL;
+        }
+
+        /* If operation was cancelled, or user doesn't set a reminder, we do nothing */
+        if (!res || password_reminder == NULL)
+                return res;
+
+        manager = act_user_manager_get_default ();
+        user = act_user_manager_get_user (manager, worker->priv->username);
+
+        /* We use password_reminder variable in user_loaded_cb() to find out if
+           we must set the password hint (password_reminder != NULL) or we need
+           to reset the password mode because user cancelled the operation
+           (password_reminder == NULL) */
+        if (act_user_is_loaded (user))
+                user_loaded_cb (user, NULL, password_reminder);
+        else
+                g_signal_connect (user, "notify::is-loaded", G_CALLBACK (user_loaded_cb), password_reminder);
+
+        return res;
+}
+
 static gboolean
 gdm_session_worker_authorize_user (GdmSessionWorker *worker,
                                    gboolean          password_is_required,
@@ -1307,6 +1370,7 @@ gdm_session_worker_authorize_user (GdmSessionWorker *worker,
 {
         int error_code;
         int authentication_flags;
+        gboolean res;
 
         g_debug ("GdmSessionWorker: determining if authenticated user (password required:%d) is authorized to session",
                  password_is_required);
@@ -1333,6 +1397,9 @@ gdm_session_worker_authorize_user (GdmSessionWorker *worker,
                         gdm_session_auditor_report_password_change_failure (worker->priv->auditor);
                 } else {
                         gdm_session_auditor_report_password_changed (worker->priv->auditor);
+                        res = set_password_hint (worker);
+                        if (!res)
+                                error_code = PAM_ABORT;
                 }
         }
 

--- a/daemon/gdm-session-worker.c
+++ b/daemon/gdm-session-worker.c
@@ -1616,120 +1616,17 @@ get_var_cb (const char *key,
 }
 
 static void
-load_env_file (GdmSessionWorker *worker,
-               GFile   *file)
+load_env_func (const char *var,
+               const char *value,
+               gpointer user_data)
 {
-        gchar *contents;
-        gchar **lines;
-        gchar *line, *p;
-        gchar *var, *var_end;
-        gchar *expanded;
-        char *filename;
-        int i;
+        GdmSessionWorker *worker = user_data;
+        char *expanded;
 
-        filename = g_file_get_path (file);
-        g_debug ("Loading env vars from %s\n", filename);
-        g_free (filename);
-
-        if (g_file_load_contents (file, NULL, &contents, NULL, NULL, NULL)) {
-                lines = g_strsplit (contents, "\n", -1);
-                g_free (contents);
-                for (i = 0; lines[i] != NULL; i++) {
-                        line = lines[i];
-                        p = line;
-                        while (g_ascii_isspace (*p))
-                                p++;
-                        if (*p == '#' || *p == '\0')
-                                continue;
-                        var = p;
-                        while (gdm_shell_var_is_valid_char (*p, p == var))
-                                p++;
-                        var_end = p;
-                        while (g_ascii_isspace (*p))
-                                p++;
-                        if (var == var_end || *p != '=') {
-                                g_warning ("Invalid env.d line '%s'\n", line);
-                                continue;
-                        }
-                        *var_end = 0;
-                        p++; /* Skip = */
-                        while (g_ascii_isspace (*p))
-                                p++;
-
-                        expanded = gdm_shell_expand (p, get_var_cb, worker);
-                        expanded = g_strchomp (expanded);
-                        gdm_session_worker_set_environment_variable (worker, var, expanded);
-                        g_free (expanded);
-                }
-                g_strfreev (lines);
-        }
-}
-
-static gint
-compare_str (gconstpointer  a,
-             gconstpointer  b)
-{
-  return strcmp (*(const char **)a, *(const char **)b);
-}
-
-static void
-gdm_session_worker_load_env_dir (GdmSessionWorker *worker,
-                                 GFile *dir)
-{
-        GFileInfo *info = NULL;
-        GFileEnumerator *enumerator = NULL;
-        GPtrArray *names = NULL;
-        GFile *file;
-        const gchar *name;
-        int i;
-
-        enumerator = g_file_enumerate_children (dir,
-                                                G_FILE_ATTRIBUTE_STANDARD_TYPE","
-                                                G_FILE_ATTRIBUTE_STANDARD_NAME","
-                                                G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN","
-                                                G_FILE_ATTRIBUTE_STANDARD_IS_BACKUP,
-                                                G_FILE_QUERY_INFO_NONE,
-                                                NULL, NULL);
-        if (!enumerator) {
-                goto out;
-        }
-
-        names = g_ptr_array_new_with_free_func (g_free);
-        while ((info = g_file_enumerator_next_file (enumerator, NULL, NULL)) != NULL) {
-                if (g_file_info_get_file_type (info) == G_FILE_TYPE_REGULAR &&
-                    !g_file_info_get_is_hidden (info) &&
-                    g_str_has_suffix (g_file_info_get_name (info), ".env"))
-                  g_ptr_array_add (names, g_strdup (g_file_info_get_name (info)));
-
-                g_clear_object (&info);
-        }
-
-        g_ptr_array_sort (names, compare_str);
-
-        for (i = 0; i < names->len; i++) {
-                name = g_ptr_array_index (names, i);
-                file = g_file_get_child (dir, name);
-                load_env_file (worker, file);
-                g_object_unref (file);
-        }
-
- out:
-        g_clear_pointer (&names, g_ptr_array_unref);
-        g_clear_object (&enumerator);
-}
-
-static void
-gdm_session_worker_load_env_d (GdmSessionWorker *worker)
-{
-        GFile *dir;
-
-        dir = g_file_new_for_path (DATADIR "/gdm/env.d");
-        gdm_session_worker_load_env_dir (worker, dir);
-        g_object_unref (dir);
-
-        dir = g_file_new_for_path (GDMCONFDIR "/env.d");
-        gdm_session_worker_load_env_dir (worker, dir);
-        g_object_unref (dir);
+        expanded = gdm_shell_expand (value, get_var_cb, worker);
+        expanded = g_strchomp (expanded);
+        gdm_session_worker_set_environment_variable (worker, var, expanded);
+        g_free (expanded);
 }
 
 static gboolean
@@ -2160,7 +2057,7 @@ gdm_session_worker_start_session (GdmSessionWorker  *worker,
 #endif
 
                 if (!worker->priv->is_program_session) {
-                        gdm_session_worker_load_env_d (worker);
+                        gdm_load_env_d (load_env_func, worker);
                 }
 
                 environment = gdm_session_worker_get_environment (worker);

--- a/daemon/gdm-x-session.c
+++ b/daemon/gdm-x-session.c
@@ -274,6 +274,8 @@ spawn_x_server (State        *state,
 
         g_ptr_array_add (arguments, "-noreset");
         g_ptr_array_add (arguments, "-keeptty");
+        g_ptr_array_add (arguments, "-sharevts");
+        g_ptr_array_add (arguments, "-novtswitch");
 
         g_ptr_array_add (arguments, "-verbose");
         if (state->debug_enabled) {

--- a/data/Init.in
+++ b/data/Init.in
@@ -6,6 +6,10 @@
 PATH="@X_PATH@:$PATH"
 OLD_IFS=$IFS
 
+# Record a successful boot (GRUB)
+recordbootstatus=/usr/lib/grub/record-boot-status
+[ -x "$recordbootstatus" ] && $recordbootstatus
+
 gdmwhich () {
   COMMAND="$1"
   OUTPUT=

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -26,6 +26,9 @@ PreSession: $(srcdir)/PreSession.in
 PostSession: $(srcdir)/PostSession.in
 	sed	-e 's,[@]X_PATH[@],$(X_PATH),g' \
 		<$(srcdir)/PostSession.in >PostSession
+PostLogin: $(srcdir)/PostLogin.in
+	sed	-e 's,[@]LIBEXECDIR[@],$(libexecdir),g' \
+		<$(srcdir)/PostLogin.in >PostLogin
 
 gdm.conf-custom: $(srcdir)/gdm.conf-custom.in
 	sed	-e 's,[@]GDM_DEFAULTS_CONF[@],$(GDM_DEFAULTS_CONF),g' \
@@ -175,7 +178,7 @@ EXTRA_DIST +=			\
 	Init.in 		\
 	PreSession.in 		\
 	PostSession.in 		\
-	PostLogin 		\
+	PostLogin.in 		\
 	$(NULL)
 
 CLEANFILES = 				\
@@ -187,6 +190,7 @@ CLEANFILES = 				\
 	Init				\
 	PreSession			\
 	PostSession			\
+	PostLogin			\
 	greeter-dconf-defaults		\
 	$(NULL)
 
@@ -235,7 +239,7 @@ uninstall-hook:
 	$(DESTDIR)$(GDM_CUSTOM_CONF) \
 	$(DESTDIR)$(gdmconfdir)/Xsession \
 	$(DESTDIR)$(initdir)/Default \
-	$(DESTDIR)$(postlogindir)/Default.sample \
+	$(DESTDIR)$(postlogindir)/Default \
 	$(DESTDIR)$(predir)/Default \
 	$(DESTDIR)$(postdir)/Default \
 	$(DESTDIR)$(sysconfdir)/dconf/db/gdm \
@@ -245,7 +249,7 @@ uninstall-hook:
 	$(DESTDIR)$(xauthdir) \
 	$(DESTDIR)$(PAM_PREFIX)/pam.d
 
-install-data-hook: gdm.conf-custom $(Xsession_files) Init PostSession PreSession
+install-data-hook: gdm.conf-custom $(Xsession_files) Init PostSession PreSession PostLogin
 	if test '!' -d $(DESTDIR)$(gdmconfdir); then \
 		$(mkinstalldirs) $(DESTDIR)$(gdmconfdir); \
 		chmod 755 $(DESTDIR)$(gdmconfdir); \
@@ -272,7 +276,10 @@ endif
 		$(mkinstalldirs) $(DESTDIR)$(postlogindir); \
 		chmod 755 $(DESTDIR)$(postlogindir); \
 	fi
-	$(INSTALL_SCRIPT) $(srcdir)/PostLogin $(DESTDIR)$(postlogindir)/Default.sample
+	-if test -f $(DESTDIR)$(postlogindir)/Default; then \
+		cp -f $(DESTDIR)$(postlogindir)/Default $(DESTDIR)$(postlogindir)/Default.orig; \
+	fi
+	$(INSTALL_SCRIPT) PostLogin $(DESTDIR)$(postlogindir)/Default
 
 	if test '!' -d $(DESTDIR)$(predir); then \
 		$(mkinstalldirs) $(DESTDIR)$(predir); \

--- a/data/PostLogin
+++ b/data/PostLogin
@@ -1,8 +1,0 @@
-#!/bin/sh
-#
-# Note: this is a sample and will not be run as is.  Change the name of this
-# file to <gdmconfdir>/PostLogin/Default for this script to be run.  This
-# script will be run before any setup is run on behalf of the user and is
-# useful if you for example need to do some setup to create a home directory
-# for the user or something like that.  $HOME, $LOGIN and such will all be
-# set appropriately and this script is run as root.

--- a/data/PostLogin.in
+++ b/data/PostLogin.in
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+DEMO_MODE_STAMP=/run/gnome-initial-setup/eos-demo-mode
+
+if [ -f ${DEMO_MODE_STAMP} ] && [ $(grep -E "^${USERNAME}$" ${DEMO_MODE_STAMP}) ]; then
+  rm -fr $HOME
+  cp -r /etc/skel $HOME
+  chown -R ${USERNAME}:${GROUP} $HOME
+fi

--- a/data/PostSession.in
+++ b/data/PostSession.in
@@ -1,3 +1,12 @@
 #!/bin/sh
 
+# Clean Shared Account brower details (cookies, cache, history, ...)
+if [ ${USERNAME} = "shared" ]; then
+  rm -fr /home/shared/.cache/chromium
+  rm -fr /home/shared/.config/chromium
+
+  # Clean Trash
+  rm -fr /home/shared/.local/share/Trash
+fi
+
 exit 0

--- a/data/PostSession.in
+++ b/data/PostSession.in
@@ -9,4 +9,14 @@ if [ ${USERNAME} = "shared" ]; then
   rm -fr /home/shared/.local/share/Trash
 fi
 
+DEMO_MODE_STAMP=/run/gnome-initial-setup/eos-demo-mode
+
+if [ -f ${DEMO_MODE_STAMP} ] && [ $(grep -E "^${USERNAME}$" ${DEMO_MODE_STAMP}) ] ; then
+  rm -fr $HOME
+  # We need to re-create the home directory again otherwise
+  # GDM will attempt to write files to it and fail
+  mkdir -p $HOME
+  chown -R $USERNAME:$GROUP $HOME
+fi
+
 exit 0

--- a/data/PreSession.in
+++ b/data/PreSession.in
@@ -6,4 +6,19 @@
 #
 # Note that output goes into the .xsession-errors file for easy debugging
 #
+
+# Clean Shared Account brower details (cookies, cache, history, ...)
+if [ ${USERNAME} = "shared" ]; then
+  rm -fr /home/shared/.cache/chromium
+  rm -fr /home/shared/.config/chromium
+  cp -Rf /etc/skel/.config/chromium /home/shared/.config
+  chown -R shared:shared /home/shared/.config/chromium
+
+  # Disable autosave passwords in Chromium
+  sed -i "s/\"password_manager_enabled\": true/\"password_manager_enabled\": false/g" /home/shared/.config/chromium/Default/Preferences
+
+  # Clean Trash
+  rm -fr /home/shared/.local/share/Trash
+fi
+
 PATH="@X_PATH@:$PATH"

--- a/data/dconf/gdm.in
+++ b/data/dconf/gdm.in
@@ -1,2 +1,3 @@
 user-db:user
+system-db:gdm
 file-db:@DATADIR@/@PACKAGE@/greeter-dconf-defaults

--- a/data/dconf/gdm.in
+++ b/data/dconf/gdm.in
@@ -1,3 +1,4 @@
 user-db:user
 system-db:gdm
 file-db:@DATADIR@/@PACKAGE@/greeter-dconf-defaults
+file-db:/var/lib/eos-image-defaults/settings

--- a/data/gdm.conf-custom.in
+++ b/data/gdm.conf-custom.in
@@ -1,8 +1,19 @@
 # GDM configuration storage
+#
+# See /usr/share/gdm/gdm.schemas for a list of available options.
 
 [daemon]
 # Uncomment the line below to force the login screen to use Xorg
 #WaylandEnable=false
+
+# Enabling automatic login
+#  AutomaticLoginEnable = true
+#  AutomaticLogin = user1
+
+# Enabling timed login
+#  TimedLoginEnable = true
+#  TimedLogin = user1
+#  TimedLoginDelay = 10
 
 [security]
 
@@ -12,5 +23,7 @@
 
 [debug]
 # Uncomment the line below to turn on debugging
+# More verbose logs
+# Additionally lets the X server dump core if it crashes
 #Enable=true
 

--- a/data/gdm.schemas.in
+++ b/data/gdm.schemas.in
@@ -33,6 +33,11 @@
       <default></default>
     </schema>
     <schema>
+      <key>daemon/ForceAutomaticLogin</key>
+      <signature>b</signature>
+      <default>false</default>
+    </schema>
+    <schema>
       <key>daemon/TimedLoginEnable</key>
       <signature>b</signature>
       <default>false</default>


### PR DESCRIPTION
In the past, we disabled user sessions entirely because the NVidia driver would collapse under the weight of two X servers. Kill the X servers instead.

This is an alternative to https://github.com/endlessm/gdm/pull/54 but needs testing.

https://phabricator.endlessm.com/T25368