### PR TITLE
manager: Chown initial-setup homedir on REUSE_VT

### DIFF
--- a/daemon/gdm-manager.c
+++ b/daemon/gdm-manager.c
@@ -1784,6 +1784,9 @@ on_start_user_session (StartUserSessionOperation *operation)
 #endif
                       NULL);
 
+        if (doing_initial_setup)
+                chown_initial_setup_home_dir ();
+
         session_id = gdm_session_get_conversation_session_id (operation->session,
                                                               operation->service_name);
 
@@ -1815,8 +1818,6 @@ on_start_user_session (StartUserSessionOperation *operation)
                                 gdm_display_unmanage (display);
                                 gdm_display_finish (display);
                         }
-
-                        chown_initial_setup_home_dir ();
 
                         if (!g_file_set_contents (ALREADY_RAN_INITIAL_SETUP_ON_THIS_BOOT,
                                                   "1",


### PR DESCRIPTION
The initial setup home dir should be owned by the initial user created
during the gnome-initial-setup to be able to copy all config to the new
user with the gnome-initial-setup-copy-worker.

The owner of this homedir is been changed if the session is different
from GDM_SESSION_DISPLAY_MODE_REUSE_VT but in this case the manager is
not calling this function.

This patch moves the call to this function outside the if-else to fix
the gnome-initial-setup process in the first case.

https://phabricator.endlessm.com/T26433