### PR TITLE
Revert "Unset 'recordfail' grub variable on GDM start"

### DIFF
--- a/data/Init.in
+++ b/data/Init.in
@@ -6,10 +6,6 @@
 PATH="@X_PATH@:$PATH"
 OLD_IFS=$IFS
 
-# Record a successful boot (GRUB)
-recordbootstatus=/usr/lib/grub/record-boot-status
-[ -x "$recordbootstatus" ] && $recordbootstatus
-
 gdmwhich () {
   COMMAND="$1"
   OUTPUT=


### PR DESCRIPTION
This reverts commit 9ec01da42ff2d7ea382b676ccbba0e3be8788460.

This approach does not work when user-display-server is enabled.

https://phabricator.endlessm.com/T26791