### PR TITLE
Revert "Full disable user display server again"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,11 @@ include /usr/share/gnome-pkg-tools/1/rules/gnome-version.mk
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,-z,defs -Wl,--as-needed
 
+ifeq (,$(filter i386 amd64,$(DEB_HOST_ARCH_CPU)))
+CONFFLAGS += \
+	--disable-user-display-server
+endif
+
 ifeq (linux,$(DEB_HOST_ARCH_OS))
 CONFFLAGS += \
 	--enable-wayland-support \
@@ -57,7 +62,6 @@ override_dh_auto_configure:
 		--libexecdir=\$${prefix}/lib/gdm3 \
 		--disable-static \
 		--enable-ipv6=yes \
-		--disable-user-display-server \
 		--with-at-spi-registryd-directory=/usr/lib/at-spi \
 		--with-default-path=/usr/local/bin:/usr/bin:/bin:/usr/games \
 		--with-custom-conf=/etc/gdm3/daemon.conf \


### PR DESCRIPTION
This reverts commit 455f9d10654744731b86b92b68968cf0c0321c07.

Build with user-display-server support again.

https://phabricator.endlessm.com/T27501