### PR TITLE
Prefer endless session as fallback over GNOME

### DIFF
--- a/daemon/gdm-session.c
+++ b/daemon/gdm-session.c
@@ -562,6 +562,14 @@ get_fallback_session_name (GdmSession *self)
                 }
         }
 
+        name = g_strdup ("endless");
+        if (get_session_command_for_name (self, name, NULL)) {
+                g_free (self->fallback_session_name);
+                self->fallback_session_name = name;
+                goto out;
+        }
+        g_free (name);
+
         name = g_strdup ("gnome");
         if (get_session_command_for_name (self, name, NULL)) {
                 g_free (self->fallback_session_name);


### PR DESCRIPTION
This makes sure the XDG_CURRENT_DESKTOP is set to
"endless:GNOME". We need this so that we can detect the current
desktop as "endless". This is required for custom session we are
going to ship so that we can have some system extenions enabled by
default for the "endless" desktop.

Also see:
https://git.launchpad.net/ubuntu/+source/gnome-shell/tree/debian/patches/ubuntu/desktop_detect.patch

Cherry-picked and modified from Ubuntu's source-code:
https://git.launchpad.net/ubuntu/+source/gdm3/tree/debian/patches/ubuntu/prefer_ubuntu_session_fallback.patch

https://phabricator.endlessm.com/T28777