### PR TITLE
Drop udev rule to disable wayland

### DIFF
--- a/debian/62-Endless-disable-wayland.rules
+++ b/debian/62-Endless-disable-wayland.rules
@@ -1,2 +1,0 @@
-# disable Wayland
-RUN+="/usr/lib/gdm3/gdm-disable-wayland"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+gdm3 (3.34.0-1endless2) eos; urgency=medium
+
+  * Drop udev rule to disable wayland (62-Endless-disable-wayland.rules).
+    This udev rule is no longer needed to disable wayland as we only enable
+    one session and gdm automatically detects it as an X session based on
+    the path it is installed (/usr/share/xsessions/endless.desktop).
+    https://phabricator.endlessm.com/T30188
+
+ -- Andre Moreira Magalhaes <andre@endlessm.com>  Tue, 19 May 2020 20:53:31 -0300
+
 gdm3 (3.34.0-1endless1) eos; urgency=medium
 
   * Add back downstream changes

--- a/debian/gdm3.install
+++ b/debian/gdm3.install
@@ -17,6 +17,5 @@ usr/share/gnome-session/
 usr/share/dconf/
 var/*
 
-debian/62-Endless-disable-wayland.rules	etc/udev/rules.d
 debian/Xsession				etc/gdm3
 debian/insserv.conf.d			etc


### PR DESCRIPTION
This udev rule is no longer needed to disable wayland as we only enable one session and GDM automatically detects it as an X session based on the path it is installed (/usr/share/xsessions/endless.desktop).

GDM only consider a session to be a wayland session if the session's configuration file path ends with "/wayland-sessions". This check is done when loading the available sessions from the configured system dirs.

https://phabricator.endlessm.com/T30188