### PR TITLE
Revert "data: Clean up the demo-guest account by removing all files a…

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -25,9 +25,6 @@ PreSession: $(srcdir)/PreSession.in
 PostSession: $(srcdir)/PostSession.in
 	sed	-e 's,[@]X_PATH[@],$(X_PATH),g' \
 		<$(srcdir)/PostSession.in >PostSession
-PostLogin: $(srcdir)/PostLogin.in
-	sed	-e 's,[@]LIBEXECDIR[@],$(libexecdir),g' \
-		<$(srcdir)/PostLogin.in >PostLogin
 
 gdm.conf-custom: $(srcdir)/gdm.conf-custom.in
 	sed	-e 's,[@]GDM_DEFAULTS_CONF[@],$(GDM_DEFAULTS_CONF),g' \
@@ -176,7 +173,7 @@ EXTRA_DIST +=			\
 	Init.in 		\
 	PreSession.in 		\
 	PostSession.in 		\
-	PostLogin.in 		\
+	PostLogin 		\
 	$(NULL)
 
 CLEANFILES = 				\
@@ -188,7 +185,6 @@ CLEANFILES = 				\
 	Init				\
 	PreSession			\
 	PostSession			\
-	PostLogin			\
 	greeter-dconf-defaults		\
 	$(NULL)
 
@@ -237,7 +233,7 @@ uninstall-hook:
 	$(DESTDIR)$(GDM_CUSTOM_CONF) \
 	$(DESTDIR)$(gdmconfdir)/Xsession \
 	$(DESTDIR)$(initdir)/Default \
-	$(DESTDIR)$(postlogindir)/Default \
+	$(DESTDIR)$(postlogindir)/Default.sample \
 	$(DESTDIR)$(predir)/Default \
 	$(DESTDIR)$(postdir)/Default \
 	$(DESTDIR)$(sysconfdir)/dconf/db/gdm \
@@ -247,7 +243,7 @@ uninstall-hook:
 	$(DESTDIR)$(xauthdir) \
 	$(DESTDIR)$(PAM_PREFIX)/pam.d
 
-install-data-hook: gdm.conf-custom $(Xsession_files) Init PostSession PreSession PostLogin
+install-data-hook: gdm.conf-custom $(Xsession_files) Init PostSession PreSession
 	if test '!' -d $(DESTDIR)$(gdmconfdir); then \
 		$(mkinstalldirs) $(DESTDIR)$(gdmconfdir); \
 		chmod 755 $(DESTDIR)$(gdmconfdir); \
@@ -274,10 +270,7 @@ endif
 		$(mkinstalldirs) $(DESTDIR)$(postlogindir); \
 		chmod 755 $(DESTDIR)$(postlogindir); \
 	fi
-	-if test -f $(DESTDIR)$(postlogindir)/Default; then \
-		cp -f $(DESTDIR)$(postlogindir)/Default $(DESTDIR)$(postlogindir)/Default.orig; \
-	fi
-	$(INSTALL_SCRIPT) PostLogin $(DESTDIR)$(postlogindir)/Default
+	$(INSTALL_SCRIPT) $(srcdir)/PostLogin $(DESTDIR)$(postlogindir)/Default.sample
 
 	if test '!' -d $(DESTDIR)$(predir); then \
 		$(mkinstalldirs) $(DESTDIR)$(predir); \

--- a/data/PostLogin
+++ b/data/PostLogin
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Note: this is a sample and will not be run as is.  Change the name of this
+# file to <gdmconfdir>/PostLogin/Default for this script to be run.  This
+# script will be run before any setup is run on behalf of the user and is
+# useful if you for example need to do some setup to create a home directory
+# for the user or something like that.  $HOME, $LOGIN and such will all be
+# set appropriately and this script is run as root.

--- a/data/PostLogin.in
+++ b/data/PostLogin.in
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-DEMO_MODE_STAMP=/run/gnome-initial-setup/eos-demo-mode
-
-if [ -f ${DEMO_MODE_STAMP} ] && [ $(grep -E "^${USERNAME}$" ${DEMO_MODE_STAMP}) ]; then
-  rm -fr $HOME
-  cp -r /etc/skel $HOME
-  chown -R ${USERNAME}:${GROUP} $HOME
-fi

--- a/data/PostSession.in
+++ b/data/PostSession.in
@@ -9,14 +9,4 @@ if [ ${USERNAME} = "shared" ]; then
   rm -fr /home/shared/.local/share/Trash
 fi
 
-DEMO_MODE_STAMP=/run/gnome-initial-setup/eos-demo-mode
-
-if [ -f ${DEMO_MODE_STAMP} ] && [ $(grep -E "^${USERNAME}$" ${DEMO_MODE_STAMP}) ] ; then
-  rm -fr $HOME
-  # We need to re-create the home directory again otherwise
-  # GDM will attempt to write files to it and fail
-  mkdir -p $HOME
-  chown -R $USERNAME:$GROUP $HOME
-fi
-
 exit 0


### PR DESCRIPTION
…nd settings"

This reverts commit f6f374d35784bfe6f735ea32271cc119c346afcd.

Demo mode is being dropped from gnome-initial-setup, so there’s no
longer a need to clean it up after use.

https://phabricator.endlessm.com/T30173