### PR TITLE
Properly load dconf profile

### DIFF
--- a/data/dconf/gdm.in
+++ b/data/dconf/gdm.in
@@ -1,4 +1,4 @@
 user-db:user
 system-db:gdm
-file-db:/var/lib/gdm3/greeter-dconf-defaults
+file-db:@DATADIR@/@PACKAGE@/greeter-dconf-defaults
 file-db:/var/lib/eos-image-defaults/settings


### PR DESCRIPTION
On Endless we ship the dconf profile under DATADIR/greeter-dconf-defaults and no profile under /var/lib/gdm3, so let's drop this debian change as it breaks for example showing the a11y menu which is configured to be displayed by default in the shipped dconf profile.

(looks like this change was added when importing debian/patches during the 3.37.9x/3.38 rebase).

https://phabricator.endlessm.com/T30874