### PR TITLE
d/rules: Set runtime configuration path

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -65,6 +65,7 @@ override_dh_auto_configure:
 		-Dcheck-accelerated-dir=/usr/lib/gnome-session/ \
 		-Dran-once-marker-dir=/run/gdm3 \
 		-Dgnome-settings-daemon-dir="`pkg-config --variable=libexecdir gnome-settings-daemon`" \
+		-Druntime-conf=/run/gdm3/daemon.conf \
 		$(CONFFLAGS)
 
 override_dh_auto_build: $(OUTFILES) $(MANPAGES)


### PR DESCRIPTION
In Autotools, the default runtime configuration path used to be
${GDM_RUN_DIR}/custom.conf, but in the Meson build system the fallback
changed to be the same as the custom.conf path in /etc (set to
/etc/gdm3/daemon.conf in Debian for historical reasons).

Explicitly set it to the path we used before switching to Meson, so
that configuration changes by gdm-disable-wayland are temporary as
intended, and do not persist to a subsequent boot.

[Cherry-picked from Debian commit ecb5e1e2f8]