### PR TITLE
data: Run the greeter session on X by default

### DIFF
--- a/data/gdm.conf-custom.in
+++ b/data/gdm.conf-custom.in
@@ -3,8 +3,9 @@
 # See /usr/share/gdm/gdm.schemas for a list of available options.
 
 [daemon]
-# Uncomment the line below to force the login screen to use Xorg
-#WaylandEnable=false
+# We change the default value to 'false' on EOS.
+# Uncomment the line below to force the login screen to use Wayland
+#WaylandEnable=true
 
 # Enabling automatic login
 #  AutomaticLoginEnable = true

--- a/data/gdm.schemas.in
+++ b/data/gdm.schemas.in
@@ -55,7 +55,7 @@
     <schema>
       <key>daemon/WaylandEnable</key>
       <signature>b</signature>
-      <default>true</default>
+      <default>false</default>
     </schema>
     <schema>
       <key>security/AllowRemoteAutoLogin</key>


### PR DESCRIPTION
We can't run on Wayland by default because the RPi4 does not support it
(it does not have a DRM driver yet), and we should avoid mixed
environments so we don't have to support both Xorg and Wayland on a
certain piece of hardware.

https://phabricator.endlessm.com/T30916