### PR TITLE
Revert "data: Run the greeter session on X by default"

### DIFF
--- a/data/gdm.conf-custom.in
+++ b/data/gdm.conf-custom.in
@@ -3,9 +3,8 @@
 # See /usr/share/gdm/gdm.schemas for a list of available options.
 
 [daemon]
-# We change the default value to 'false' on EOS.
-# Uncomment the line below to force the login screen to use Wayland
-#WaylandEnable=true
+# Uncomment the line below to force the login screen to use Xorg
+#WaylandEnable=false
 
 # Enabling automatic login
 #  AutomaticLoginEnable = true

--- a/data/gdm.schemas.in
+++ b/data/gdm.schemas.in
@@ -55,7 +55,7 @@
     <schema>
       <key>daemon/WaylandEnable</key>
       <signature>b</signature>
-      <default>false</default>
+      <default>true</default>
     </schema>
     <schema>
       <key>security/AllowRemoteAutoLogin</key>


### PR DESCRIPTION
This reverts commit 2630cf6593456709c4122764bf1b0ac336d7c155.

GDM and Xorg/Wayland work together. GDM falls back to Xorg, if Wayland
is failed. Xorg.wrap (from T30918) will check the DRM to determine the
root access for Xorg on arm64. So, commit 2630cf65934567 ("data: Run the
greeter session on X by default") can be reverted safely.

https://phabricator.endlessm.com/T30597