### PR TITLE
utils: add enabling Wayland feature into gdm-disable-wayland

### DIFF
--- a/utils/gdm-disable-wayland.c
+++ b/utils/gdm-disable-wayland.c
@@ -22,30 +22,47 @@
 
 #include <locale.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sysexits.h>
 
 #include <glib.h>
+
+/* Return TRUE if we want to disable Wayland */
+gboolean
+parse_disable_wayland(char *argv)
+{
+        if (argv[0] == "0" ||
+            !strncmp(argv, "FALSE\0", 6) ||
+            !strncmp(argv, "false\0", 6))
+                return FALSE;
+        else
+                return TRUE;
+}
 
 int
 main (int argc, char *argv[])
 {
         g_autoptr(GKeyFile) key_file = NULL;
         g_autoptr(GError) error = NULL;
+        gboolean wayland_flag = FALSE;
         gboolean saved_okay;
+
+        if (argc > 1)
+                wayland_flag = !parse_disable_wayland(argv[1]);
 
         setlocale (LC_ALL, "");
 
         key_file = g_key_file_new ();
 
-        g_key_file_set_boolean (key_file, "daemon", "WaylandEnable", FALSE);
+        g_key_file_set_boolean (key_file, "daemon", "WaylandEnable", wayland_flag);
 
         g_mkdir_with_parents (GDM_RUN_DIR, 0711);
 
         saved_okay = g_key_file_save_to_file (key_file, GDM_RUNTIME_CONF, &error);
 
         if (!saved_okay) {
-                g_printerr ("gdm-disable-wayland: unable to disable wayland: %s",
-                            error->message);
+                g_printerr ("gdm-disable-wayland: unable to %s wayland: %s",
+                            wayland_flag ? "enable" : "disable", error->message);
                 return EX_CANTCREAT;
         }
 


### PR DESCRIPTION
We can disable Wayland in runtime by invoking gdm-disable-wayland.
However, we may also want to enable Wayland in runtime for some
reasons.

This commit extends gdm-disable-wayland by parsing the argument. It not
only keeps disable Wayland by default, but also parses the argument if
users want to enable the Wayland by passing "false", "FALSE" or "0" to
gdm-disable-wayland command.

https://phabricator.endlessm.com/T30597