### PR TITLE
Add udev rule to enable Wayland on arm64 if DRM presents

### DIFF
--- a/debian/62-Endless-enable-wayland.rules
+++ b/debian/62-Endless-enable-wayland.rules
@@ -1,0 +1,2 @@
+# Eanble Wayland if there is the DRM
+SUBSYSTEM=="graphics", KERNEL=="fb0", ATTR{name}!="simple", RUN+="/usr/lib/gdm3/gdm-disable-wayland FALSE"

--- a/debian/gdm3.install
+++ b/debian/gdm3.install
@@ -13,5 +13,6 @@ usr/share/gdm/
 usr/share/gnome-session/
 usr/share/dconf/
 
-debian/Xsession				etc/gdm3
-debian/insserv.conf.d			etc
+[arm64] debian/62-Endless-enable-wayland.rules	etc/udev/rules.d
+debian/Xsession					etc/gdm3
+debian/insserv.conf.d				etc


### PR DESCRIPTION
Arm64 devices with supported DRM have better UI performance with
Wayland. EOS keeps Xorg by default for all platforms. So, this patch
only makes Wayland enabled on arm64 in runtime if the DRM is detected
(not simple frame buffer in used).

https://phabricator.endlessm.com/T30597