### PR TITLE
utils: change gdm-disable-wayland to gdm-runtime-config

### DIFF
--- a/data/61-gdm.rules.in
+++ b/data/61-gdm.rules.in
@@ -1,6 +1,6 @@
 # disable Wayland on Hi1710 chipsets
-ATTR{vendor}=="0x19e5", ATTR{device}=="0x1711", RUN+="@libexecdir@/gdm-disable-wayland"
+ATTR{vendor}=="0x19e5", ATTR{device}=="0x1711", RUN+="@libexecdir@/gdm-runtime-config set daemon WaylandEnable false"
 # disable Wayland when using the proprietary nvidia driver
-DRIVER=="nvidia", RUN+="@libexecdir@/gdm-disable-wayland"
+DRIVER=="nvidia", RUN+="@libexecdir@/gdm-runtime-config set daemon WaylandEnable false"
 # disable Wayland if modesetting is disabled
-IMPORT{cmdline}="nomodeset", RUN+="@libexecdir@/gdm-disable-wayland"
+IMPORT{cmdline}="nomodeset", RUN+="@libexecdir@/gdm-runtime-config set daemon WaylandEnable false"

--- a/utils/meson.build
+++ b/utils/meson.build
@@ -26,14 +26,14 @@ gdm_screenshot = executable('gdm-screenshot',
   install: true,
 )
 
-# gdm-disable-wayland
-gdm_disable_wayland_deps = [
+# gdm-runtime-config
+gdm_runtime_config_deps = [
   glib_dep,
 ]
 
-gdm_disable_wayland = executable('gdm-disable-wayland',
-  'gdm-disable-wayland.c',
-  dependencies: gdm_disable_wayland_deps,
+gdm_runtime_config = executable('gdm-runtime-config',
+  'gdm-runtime-config.c',
+  dependencies: gdm_runtime_config_deps,
   include_directories: config_h_dir,
   install: true,
   install_dir: get_option('libexecdir'),


### PR DESCRIPTION
We can disable Wayland in runtime by invoking gdm-disable-wayland.
However, we may also want to enable Wayland in runtime for some
reasons. This idea is extended to modify more options/configurations in
runtime.

This commit renames gdm-disable-wayland to gdm-runtime-config and
unlocks the feature to modify more gdm configurations in runtime.
The new command format will be:
  gdm-runtime-config set <group> <key> <value>

The configurable items refer to gdm.schemas. "<group>/<key>" combination
is the key in gdm.schemas.

For example, the original "gdm-disable-wayland" is replaced by
"gdm-runtime-config set daemon WaylandEnable false".

Link: https://gitlab.gnome.org/GNOME/gdm/-/merge_requests/115#note_944907