### PR TITLE
Revert "Add udev rule to enable Wayland on arm64 if DRM presents"

### DIFF
--- a/debian/62-Endless-enable-wayland.rules
+++ b/debian/62-Endless-enable-wayland.rules
@@ -1,2 +1,0 @@
-# Enable Wayland if there is DRM
-SUBSYSTEM=="graphics", KERNEL=="fb0", ATTR{name}!="simple", RUN+="/usr/lib/gdm3/gdm-runtime-config set daemon WaylandEnable true"

--- a/debian/gdm3.install
+++ b/debian/gdm3.install
@@ -13,6 +13,5 @@ usr/share/gdm/
 usr/share/gnome-session/
 usr/share/dconf/
 
-[arm64] debian/62-Endless-enable-wayland.rules	etc/udev/rules.d
-debian/Xsession					etc/gdm3
-debian/insserv.conf.d				etc
+debian/Xsession				etc/gdm3
+debian/insserv.conf.d			etc


### PR DESCRIPTION
This reverts commit 8d9402a83d560ed6ee56c2ff20a9d6e7794ed2b4.

We're making Wayland the default, on all platforms that Wayland is
used as default, making the reverted patch obsolete.

https://phabricator.endlessm.com/T31623