### PR TITLE
udev: Allow wayland on hybrid vendor nvidia machines

### DIFF
--- a/data/61-gdm.rules.in
+++ b/data/61-gdm.rules.in
@@ -84,12 +84,14 @@ ACTION!="add", GOTO="gdm_hybrid_graphics_check_end"
 RUN+="/usr/bin/touch /run/udev/gdm-machine-has-hybrid-graphics"
 LABEL="gdm_hybrid_graphics_check_end"
 
-# If this is a hybrid graphics laptop with vendor nvidia driver, disable wayland
+# If this is a hybrid graphics laptop with vendor nvidia driver default to wayland
+# It gives poor performance for multi-monitor, but Xorg fails some multi-monitor
+# setups too, and this is what we did in F36.
 LABEL="gdm_hybrid_nvidia_laptop_check"
 TEST!="/run/udev/gdm-machine-is-laptop", GOTO="gdm_hybrid_nvidia_laptop_check_end"
 TEST!="/run/udev/gdm-machine-has-hybrid-graphics", GOTO="gdm_hybrid_nvidia_laptop_check_end"
 TEST!="/run/udev/gdm-machine-has-vendor-nvidia-driver", GOTO="gdm_hybrid_nvidia_laptop_check_end"
-GOTO="gdm_disable_wayland"
+GOTO="gdm_end"
 LABEL="gdm_hybrid_nvidia_laptop_check_end"
 
 # Disable wayland in situation where we're in a guest with a virtual gpu and host passthrough gpu


### PR DESCRIPTION
We currently disable wayland on machines with the vendor nvidia driver upstream if hybrid graphics are in place because there is poor performance for multimonitor use cases.

But springing that change on users in F37 this late in the game isn't nice, so instead default to Xorg and provide wayland as an option in the menu.

https://bugzilla.redhat.com/show_bug.cgi?id=2128910

Have this patch from Fedora gdm.

Source: https://src.fedoraproject.org/rpms/gdm/c/27625e5ff87b21ad983d2bb53541361a7201755a

https://phabricator.endlessm.com/T35012